### PR TITLE
refactor(layout): Prepare la base layout structure para la integracion con UX 

### DIFF
--- a/apps/frontend/App.tsx
+++ b/apps/frontend/App.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { HashRouter } from "react-router-dom";
 import { AuthProvider } from "./src/context/AuthContext";
-import { Layout } from "./src/components/layout/Layout";
+
 import { LoadingSpinner } from "./src/components/layout/LoadingSpinner";
 import { AppRoutes } from "./src/routes/AppRoutes";
 import { useAuth } from "./src/hooks/useAuth";
@@ -14,9 +14,9 @@ const AppContent: React.FC = () => {
   }
 
   return (
-    <Layout>
+
       <AppRoutes />
-    </Layout>
+    
   );
 };
 

--- a/apps/frontend/src/components/layout/AuthLayout.tsx
+++ b/apps/frontend/src/components/layout/AuthLayout.tsx
@@ -1,0 +1,19 @@
+import React from "react"
+import Layout from "./Layout"
+
+interface AuthLayoutProps {
+  children: React.ReactNode;
+}
+
+
+export default function AuthLayout ({ children }: AuthLayoutProps) {
+  return (
+    <Layout
+    header={null}
+    sidebar = {null}
+    className= "flex items-center justify-center "
+    >
+      <div className="w-full max-w-md p-4">{children}</div>
+    </Layout>
+  )
+}

--- a/apps/frontend/src/components/layout/Layout.tsx
+++ b/apps/frontend/src/components/layout/Layout.tsx
@@ -1,14 +1,47 @@
-import React from 'react';
+import React from "react";
 
 interface LayoutProps {
   children: React.ReactNode;
   className?: string;
+  header?: React.ReactNode | null;
+  sidebar?: React.ReactNode | null;
 }
 
-export const Layout: React.FC<LayoutProps> = ({ children, className = '' }) => {
+export const Layout: React.FC<LayoutProps> = ({
+  children,
+  className = "",
+  header,
+  sidebar,
+}) => {
   return (
-    <div className={`min-h-screen bg-slate-950 text-slate-200 selection:bg-indigo-500/30 ${className}`}>
-      {children}
+    <div className={`min-h-screen bg-slate-950 text-slate-200 ${className}`}>
+      <header className="sticky top-0 z-10 border-b border-slate-800 bg-slate-950/80 backdrop-blur">
+        {header === undefined ? (
+          <div className="px-4 py-3">
+            <span className="text-sm text-slate-400">Header placeholder</span>
+          </div>
+        ) : (
+          header
+        )}
+      </header>
+
+      <div className="flex min-h-[calc(100vh-56px)]">
+        {sidebar === null ? null : (
+          <aside className="hidden w-64 border-r border-slate-800 md:block">
+            {sidebar === undefined ? (
+              <div className="p-4">
+                <span className="text-sm text-slate-400">
+                  Sidebar placeholder
+                </span>
+              </div>
+            ) : (
+              sidebar
+            )}
+          </aside>
+        )}
+
+        <main className="flex-1 p-4">{children}</main>
+      </div>
     </div>
   );
 };

--- a/apps/frontend/src/routes/AppRoutes.tsx
+++ b/apps/frontend/src/routes/AppRoutes.tsx
@@ -2,6 +2,10 @@ import React from "react";
 import { Routes, Route, Navigate } from "react-router-dom";
 import ProtectedRoute from "./ProtectedRoute";
 import PublicRoute from "./PublicRoute";
+
+import Layout from "../components/layout/Layout";
+import AuthLayout from "../components/layout/AuthLayout";
+
 import Login from "../pages/Login";
 import Register from "../pages/Register";
 import Dashboard from "../pages/Dashboard";
@@ -9,11 +13,14 @@ import Dashboard from "../pages/Dashboard";
 export const AppRoutes: React.FC = () => {
   return (
     <Routes>
+      {/* Public/Auth routes */}
       <Route
         path="/login"
         element={
           <PublicRoute>
-            <Login />
+            <AuthLayout>
+              <Login />
+            </AuthLayout>
           </PublicRoute>
         }
       />
@@ -21,18 +28,25 @@ export const AppRoutes: React.FC = () => {
         path="/register"
         element={
           <PublicRoute>
-            <Register />
+            <AuthLayout>
+              <Register />
+            </AuthLayout>
           </PublicRoute>
         }
       />
+
+      {/* Protected/App routes */}
       <Route
         path="/dashboard"
         element={
           <ProtectedRoute>
-            <Dashboard />
+            <Layout>
+              <Dashboard />
+            </Layout>
           </ProtectedRoute>
         }
       />
+
       <Route path="/" element={<Navigate to="/login" replace />} />
     </Routes>
   );


### PR DESCRIPTION
Este PR prepara la estructura base del proyecto para integrar sin fricción las pantallas que entregará UX.  
Se organiza el layout y el enrutado para evitar reestructurar el proyecto cuando se incorporen las vistas.

---

## Cambios realizados

### Separación de layouts

- `/login` y `/register` renderizan dentro de **AuthLayout** (sin header/sidebar).
- `/dashboard` renderiza dentro de **Layout** (estructura base de aplicación).

### Ajustes estructurales

- Se elimina el wrapper global `<Layout>` en `AppContent` para evitar layouts duplicados y permitir que cada ruta defina su layout.
- Se ajusta el enrutado para envolver correctamente rutas públicas y privadas.

---

## Alcance

- No se agregan pantallas finales ni estilos definitivos.
- Se mantiene una estructura clara, ordenada y reutilizable para integrar las vistas de UX sin cambios estructurales adicionales.

---
