### PR TITLE
feat(frontend): auth login + password recovery

### DIFF
--- a/apps/frontend/index.html
+++ b/apps/frontend/index.html
@@ -19,6 +19,12 @@
               "menu-active": "#4e63a8",
               "primary": "#4f46e5",
               "primary-hover": "#4338ca",
+        'blackbox-yellow': '#F2B705',
+        'blackbox-white': '#F8F8F8',
+        'blackbox-blue': '#4E63A8',
+  'blackbox-success': '#22c55e',
+  'blackbox-warning': '#f59e0b',
+  'blackbox-error':   '#ef4444',
             },
           },
         },
@@ -33,7 +39,7 @@
     <style>
       body {
         font-family: "Inter", sans-serif;
-        background-color: #0f172a;
+        background-color: #F8F8F8;
         color: #f8fafc;
       }
       /* Custom scrollbar for better aesthetics */
@@ -72,7 +78,7 @@
         }
       }
     </script>
-    <link rel="stylesheet" href="/index.css" />
+    <link rel="stylesheet" href="src/output.css" />
   </head>
   <body>
     <div id="root"></div>

--- a/apps/frontend/src/components/common/Button.tsx
+++ b/apps/frontend/src/components/common/Button.tsx
@@ -17,7 +17,7 @@ export const Button: React.FC<ButtonProps> = ({
 
   const variants = {
     primary:
-      "bg-indigo-600 hover:bg-indigo-500 text-white shadow-lg shadow-indigo-500/20",
+      "bg-blackbox-yellow hover:bg-blackbox-yellow/90 text-blackbox-white shadow-lg shadow-blackbox-yellow/30 hover:shadow-blackbox-yellow/50",
     secondary: "bg-slate-700 hover:bg-slate-600 text-white",
     outline: "border border-slate-600 hover:bg-slate-800 text-slate-200",
     ghost: "hover:bg-slate-800 text-slate-300",

--- a/apps/frontend/src/components/ui/ForgotPasswordEmailStep.tsx
+++ b/apps/frontend/src/components/ui/ForgotPasswordEmailStep.tsx
@@ -33,7 +33,7 @@ export default function ForgotPasswordEmailStep({ onSubmit, isLoading = false, e
       </p>
 
 
-     
+
 
       <div className="space-y-4">
         <div className="space-y-2">
@@ -61,7 +61,7 @@ export default function ForgotPasswordEmailStep({ onSubmit, isLoading = false, e
           type="button"
           onClick={() => onSubmit(email)}
           disabled={isLoading || !email}
-          className={`w-full py-2.5 bg-[var(--accent)] text-[var(--bg)] font-bold rounded-lg border-none cursor-pointer tracking-wider transition-all duration-200 text-sm font-['DM_Sans',sans-serif] ${isLoading || !email
+          className={`w-full py-2.5 bg-blackbox-yellow text-black font-bold rounded-lg border-none cursor-pointer tracking-wider transition-all duration-200 text-sm font-lato ${isLoading || !email
               ? "cursor-not-allowed opacity-80"
               : "hover:shadow-lg shadow-[var(--accent)]/30"
             }`}

--- a/apps/frontend/src/hooks/useAuth.ts
+++ b/apps/frontend/src/hooks/useAuth.ts
@@ -1,38 +1,57 @@
 import { useAuth as useAuthContext } from '../context/AuthContext';
 import { User } from '../types';
+import { api } from '../services/api';
 import { authMock } from '../services/authMock';
+import { storage } from '../utils/storage';
 
 export const useAuth = () => {
   const { authState, login, logout, setLoading, setError } = useAuthContext();
 
+  const wait = (ms: number) =>
+    new Promise((resolve) => setTimeout(resolve, ms));
+
+  const ensureMinDelay = async (startMs: number, minMs: number) => {
+    const elapsed = Date.now() - startMs;
+    if (elapsed < minMs) {
+      await wait(minMs - elapsed);
+    }
+  };
+
   const loginUser = async (email: string, password: string) => {
+    const startedAt = Date.now();
     setLoading(true);
     setError(null);
 
     try {
-      const response = await authMock.login(email, password);
+      const response = await api.login({ email, password });
+      if (response.token) {
+        storage.setToken(response.token);
+      }
       login(response.user);
       return response;
     } catch (err: any) {
-      setError(err.message || 'Error al iniciar sesión');
+      setError(err.message || 'Error al iniciar sesiÃ³n');
       throw err;
     } finally {
+      await ensureMinDelay(startedAt, 800);
       setLoading(false);
     }
   };
 
   const registerUser = async (userData: any) => {
+    const startedAt = Date.now();
     setLoading(true);
     setError(null);
 
     try {
-      const response = await authMock.register(userData);
+      const response = await api.register(userData);
       login(response.user);
       return response;
     } catch (err: any) {
       setError(err.message || 'Error al registrar usuario');
       throw err;
     } finally {
+      await ensureMinDelay(startedAt, 800);
       setLoading(false);
     }
   };
@@ -56,6 +75,6 @@ export const useAuth = () => {
     setLoading,
     setError,
     clearError,
-    testUsers: authMock.getTestUsers()
+    testUsers: authMock.getTestUsers(),
   };
 };

--- a/apps/frontend/src/hooks/useAuthRecovery.ts
+++ b/apps/frontend/src/hooks/useAuthRecovery.ts
@@ -1,22 +1,15 @@
 import { useState } from "react";
 import { API_ENDPOINTS } from "@/src/constants/routes";
 
-// Mock data for testing
-const MOCK_USERS = [
-  { email: "test@example.com", name: "Usuario Test" },
-  { email: "admin@blackbox.com", name: "Administrador" },
-  { email: "user@demo.com", name: "Usuario Demo" }
-];
-
-const MOCK_RESPONSES = {
-  success: {
-    message: "Correo de recuperación enviado exitosamente",
-    resetToken: "mock-reset-token-12345"
-  },
-  error: {
-    notFound: "No existe una cuenta con este correo electrónico",
-    serverError: "Error del servidor al enviar el correo"
+const buildErrorMessage = async (response: Response, fallback: string) => {
+  try {
+    const data = await response.json();
+    const msg = data?.error || data?.message;
+    if (msg) return msg;
+  } catch {
+    // ignore JSON parse errors
   }
+  return fallback;
 };
 
 export function useAuthRecovery() {
@@ -30,29 +23,23 @@ export function useAuthRecovery() {
     setError(null);
 
     try {
-      // Simulate API call delay
-      await new Promise((resolve) => setTimeout(resolve, 1500));
+      const response = await fetch(
+        `${API_ENDPOINTS.BASE}${API_ENDPOINTS.AUTH.FORGOT_PASSWORD}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email }),
+        },
+      );
 
-      // Mock validation - check if email exists in our mock data
-      const userExists = MOCK_USERS.some(user => user.email.toLowerCase() === email.toLowerCase());
-
-      if (!userExists) {
-        throw new Error(MOCK_RESPONSES.error.notFound);
+      if (!response.ok) {
+        throw new Error(await buildErrorMessage(response, "Error al enviar correo de recuperación"));
       }
-
-      // Mock successful API response
-      const response = MOCK_RESPONSES.success;
-      console.log('Mock API Response:', response);
-
-      // Simulate storing the reset token (in real app, this would be handled by backend)
-      localStorage.setItem('mockResetToken', response.resetToken);
-      localStorage.setItem('resetEmail', email);
 
       setSentEmail(email);
       setStep("success");
-
     } catch (err: any) {
-      setError(err.message || "Lo sentimos, no se pudo enviar el correo de recuperación, inténtalo de nuevo.");
+      setError(err.message || "Lo sentimos, hubo un error al enviar el correo de recuperación");
     } finally {
       setIsLoading(false);
     }
@@ -63,31 +50,29 @@ export function useAuthRecovery() {
     setError(null);
 
     try {
-      // Simulate API call delay
-      await new Promise((resolve) => setTimeout(resolve, 1000));
+      if (newPassword.length < 6) {
+        throw new Error("La contraseña debe tener al menos 6 caracteres");
+      }
 
-      // Mock token validation
-      const storedToken = token || localStorage.getItem('mockResetToken');
-      const storedEmail = localStorage.getItem('resetEmail');
-
+      const storedToken = token;
       if (!storedToken) {
         throw new Error("Token de restablecimiento inválido o expirado");
       }
 
-      // Mock password validation
-      if (newPassword.length < 8) {
-        throw new Error("La contraseña debe tener al menos 8 caracteres");
+      const response = await fetch(
+        `${API_ENDPOINTS.BASE}${API_ENDPOINTS.AUTH.RESET_PASSWORD}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ token: storedToken, newPassword }),
+        },
+      );
+
+      if (!response.ok) {
+        throw new Error(await buildErrorMessage(response, "Error al restablecer la contraseña"));
       }
 
-      // Mock successful password reset
-      console.log('Mock: Password reset successfully for email:', storedEmail);
-
-      // Clean up mock data
-      localStorage.removeItem('mockResetToken');
-      localStorage.removeItem('resetEmail');
-
       return { success: true };
-
     } catch (err: any) {
       setError(err.message || "Error al restablecer la contraseña");
       throw err;
@@ -100,14 +85,10 @@ export function useAuthRecovery() {
     setStep("email");
     setSentEmail("");
     setError(null);
-    // Clean up any existing mock data
-    localStorage.removeItem('mockResetToken');
-    localStorage.removeItem('resetEmail');
   };
 
-  // Helper function to check if we have a valid reset flow
   const hasActiveResetFlow = () => {
-    return localStorage.getItem('mockResetToken') !== null;
+    return false;
   };
 
   return {
@@ -119,10 +100,5 @@ export function useAuthRecovery() {
     resetPassword,
     reset,
     hasActiveResetFlow,
-    // Mock data for testing
-    mockData: {
-      testEmails: MOCK_USERS.map(u => u.email),
-      availableUsers: MOCK_USERS
-    }
   };
 }

--- a/apps/frontend/src/hooks/useDocumentTitle.ts
+++ b/apps/frontend/src/hooks/useDocumentTitle.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from "react";
+
+/**Creo un custom hook para hacer dinamico el titulo de la pagina*/
+
+/**
+ *
+ * @param {string} title
+ * El titulo que se desa mostrar el hook lo añadira automaticamente seguido con el sufrijo blackbox
+ */
+
+
+export const useDocumentTitle = (title: string) => {
+  const [documentTitle, setDocumentTitle] = useState(title);
+
+  useEffect(() => {
+    document.title = `BlackBox - ${documentTitle}`;
+  }, [documentTitle]);
+
+  const updateTitle = (newTitle: string) => {
+    setDocumentTitle(newTitle);
+  };
+
+  return { documentTitle, updateTitle };
+};

--- a/apps/frontend/src/input.css
+++ b/apps/frontend/src/input.css
@@ -4,6 +4,6 @@
 
 @layer base {
   body {
-    background-color: #0B1001;
+   background:  #fffff8;
   }
 }

--- a/apps/frontend/src/pages/ChoferFichaPage.tsx
+++ b/apps/frontend/src/pages/ChoferFichaPage.tsx
@@ -6,6 +6,7 @@ import { PageDataContainer } from "../components/dataPage";
 import { useApi } from "../hooks/useApi";
 import { api } from "../services/api";
 import type { ChoferFicha } from "../types/dataPages";
+import { useDocumentTitle } from "@/src/hooks/useDocumentTitle";
 
 const StatusTruckIcon = () => (
   <svg
@@ -27,6 +28,7 @@ const StatusTruckIcon = () => (
 );
 
 const ChoferFichaPage: React.FC = () => {
+  useDocumentTitle("Ficha de Chofer");
   const { idChofer } = useParams();
 
   const fetchChofer = useCallback(() => api.getChoferById(idChofer ?? ""), [idChofer]);

--- a/apps/frontend/src/pages/ChoferesPage.tsx
+++ b/apps/frontend/src/pages/ChoferesPage.tsx
@@ -12,6 +12,7 @@ import {
 import { useApi } from "../hooks/useApi";
 import { api } from "../services/api";
 import type { Chofer } from "../types/dataPages";
+import { useDocumentTitle } from "@/src/hooks/useDocumentTitle";
 
 const PAGE_SIZE = 5;
 
@@ -33,6 +34,7 @@ const SearchIcon = () => (
 );
 
 const ChoferesPage: React.FC = () => {
+  useDocumentTitle("Informacion de Choferes");
   const [searchId, setSearchId] = useState("");
 
   const fetchChoferes = useCallback(() => api.getChoferes(), []);

--- a/apps/frontend/src/pages/Dashboard.tsx
+++ b/apps/frontend/src/pages/Dashboard.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useNavigate } from "react-router-dom";
 import { ROUTES } from "../constants/routes";
+import { useDocumentTitle } from "@/src/hooks/useDocumentTitle";
 
 const IconPlus = () => (
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="w-4 h-4 text-[#3F51B5]">
@@ -57,6 +58,7 @@ const activities = [
 ];
 
 const Dashboard: React.FC = () => {
+  useDocumentTitle("Dashboard");
   const navigate = useNavigate();
   return (
     <div className="min-h-full">

--- a/apps/frontend/src/pages/FlotaPage.tsx
+++ b/apps/frontend/src/pages/FlotaPage.tsx
@@ -11,6 +11,7 @@ import {
 import { useApi } from "../hooks/useApi";
 import { api } from "../services/api";
 import type { UnidadFlota } from "../types/dataPages";
+import { useDocumentTitle } from "@/src/hooks/useDocumentTitle";
 
 const PAGE_SIZE = 5;
 
@@ -45,6 +46,7 @@ function EstadoBadge({ estado }: { estado: string }) {
 }
 
 const FlotaPage: React.FC = () => {
+  useDocumentTitle("Inventario Flota");
   const [searchId, setSearchId] = useState("");
 
   const fetchFlota = useCallback(() => api.getFlota(), []);

--- a/apps/frontend/src/pages/GestionFlota.tsx
+++ b/apps/frontend/src/pages/GestionFlota.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { useDocumentTitle } from "@/src/hooks/useDocumentTitle";
 
 interface FlotaRow {
   id: string;
@@ -75,6 +76,7 @@ const SearchIcon = () => (
 );
 
 export default function GestionFlota() {
+  useDocumentTitle("Gestion de Flota");
   const [currentPage, setCurrentPage] = useState("2");
 
   return (

--- a/apps/frontend/src/pages/HistorialPage.tsx
+++ b/apps/frontend/src/pages/HistorialPage.tsx
@@ -14,6 +14,7 @@ import {
 import { useApi } from "../hooks/useApi";
 import { api } from "../services/api";
 import type { RegistroHistorial, CriterioHistorial } from "../types/dataPages";
+import { useDocumentTitle } from "@/src/hooks/useDocumentTitle";
 
 const PAGE_SIZE = 5;
 
@@ -56,6 +57,7 @@ export interface HistorialFilterState {
 }
 
 const HistorialPage: React.FC = () => {
+  useDocumentTitle("Historial de eventos");
   const [criterio, setCriterio] = useState<CriterioHistorial>("idUnidad");
   const [inputVal, setInputVal] = useState("");
   const [filterVal, setFilterVal] = useState("");

--- a/apps/frontend/src/pages/HistorialReportePage.tsx
+++ b/apps/frontend/src/pages/HistorialReportePage.tsx
@@ -11,10 +11,12 @@ import {
 import { useApi } from "../hooks/useApi";
 import { api } from "../services/api";
 import type { EventoReporte } from "../types/dataPages";
+import { useDocumentTitle } from "@/src/hooks/useDocumentTitle";
 
 const PAGE_SIZE = 5;
 
 const HistorialReportePage: React.FC = () => {
+  useDocumentTitle("Registro Consolidado de Eventos");
   const { idUnidad } = useParams<{ idUnidad: string }>();
 
   const fetchReporte = useCallback(

--- a/apps/frontend/src/pages/NuevaInspeccionPage.tsx
+++ b/apps/frontend/src/pages/NuevaInspeccionPage.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { ROUTES } from "../constants/routes";
+import { useDocumentTitle } from "@/src/hooks/useDocumentTitle";
 
 // Mock data
 interface MockVehicle {
@@ -69,6 +70,7 @@ const IconArrowRight = () => (
 );
 
 const NuevaInspeccionPage: React.FC = () => {
+  useDocumentTitle("Nueva Inspeccion");
   const navigate = useNavigate();
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [step, setStep] = useState<1 | 2 | 3>(1);

--- a/apps/frontend/src/pages/PlaceholderPage.tsx
+++ b/apps/frontend/src/pages/PlaceholderPage.tsx
@@ -1,14 +1,18 @@
 import React from "react";
+import { useDocumentTitle } from "@/src/hooks/useDocumentTitle";
 
 interface PlaceholderPageProps {
   title: string;
 }
 
-export const PlaceholderPage: React.FC<PlaceholderPageProps> = ({ title }) => (
-  <div className="py-8">
-    <h1 className="text-2xl font-bold text-white mb-2">{title}</h1>
-    <p className="text-slate-400">Página en construcción.</p>
-  </div>
-);
+export const PlaceholderPage: React.FC<PlaceholderPageProps> = ({ title }) => {
+  useDocumentTitle(title);
+  return (
+    <div className="py-8">
+      <h1 className="text-2xl font-bold text-white mb-2">{title}</h1>
+      <p className="text-slate-400">PÃ¡gina en construcciÃ³n.</p>
+    </div>
+  );
+};
 
 export default PlaceholderPage;

--- a/apps/frontend/src/pages/auth/Login.tsx
+++ b/apps/frontend/src/pages/auth/Login.tsx
@@ -5,32 +5,36 @@ import isotipoBlackbox from "@/src/assets/Isotipos/isotipo_blackbox.png";
 import Maskgroup from "@/src/assets/Logo/Maskgroup.png";
 import { Eye, EyeOff } from "lucide-react";
 import ForgotPasswordModal from "@/src/components/ForgotPasswordModal";
+import { useDocumentTitle } from "@/src/hooks/useDocumentTitle";
+
+
 
 const Login: React.FC = () => {
+  useDocumentTitle("Iniciar sesion");
   const navigate = useNavigate();
-  const { login, loading, error, testUsers } = useAuth();
+  const { login, loading, error } = useAuth();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [rememberMe, setRememberMe] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
 
-    try {
-      await login(email, password);
-      navigate("/dashboard");
-    } catch (err) {
-    }
-  };
 
-  const handleQuickLogin = (testEmail: string, testPassword: string) => {
-    setEmail(testEmail);
-    setPassword(testPassword);
-  };
+const handleSubmit = async (e:React.FormEvent) => {
+  e.preventDefault();
+  await login(email, password);
+try{
+ navigate("/dashboard");
+}catch(err){
+  console.error("hubo un error al iniciar seccion:", err);
+}
+
+
+}
+
 
   return (
-    <div className="min-h-screen overflow-hidden flex items-center justify-center gap-12 p-8 md:p-6 md:gap-8 lg:gap-8 font-['DM_Sans',sans-serif]">
+    <div className="min-h-screen bg-white overflow-hidden flex items-center justify-center gap-12 p-8 md:p-6 md:gap-8 lg:gap-8 font-['DM_Sans',sans-serif]">
       <div className="hidden md:flex lg:flex flex-shrink-0 md:max-w-[280px] lg:max-w-none">
         <img
           src={isotipoBlackbox}
@@ -49,24 +53,9 @@ const Login: React.FC = () => {
           Ingresa a tu cuenta
         </h2>
 
-        <div className="bg-blue-900/30 border border-blue-700/50 rounded-lg p-3 mb-4">
-          <p className="text-xs text-blue-300 font-medium mb-2">Pruebas rápidas:</p>
-          <div className="flex flex-wrap gap-2">
-            {testUsers.map((user, index) => (
-              <button
-                key={index}
-                type="button"
-                onClick={() => handleQuickLogin(user.email, user.password)}
-                disabled={loading}
-                className="text-xs bg-blue-800 hover:bg-blue-700 text-blue-100 px-2 py-1 rounded transition-colors disabled:opacity-50"
-              >
-                {user.email}
-              </button>
-            ))}
-          </div>
-        </div>
 
-        <form onSubmit={handleSubmit} noValidate className="space-y-5">
+
+        <form onSubmit={handleSubmit}  className="space-y-5">
           <div>
             <label
               htmlFor="email"
@@ -142,13 +131,15 @@ const Login: React.FC = () => {
 
           <button
             type="submit"
-            disabled={loading}
-            className={`w-full py-2.5 bg-[var(--accent)] text-[var(--bg)] font-bold rounded-lg border-none cursor-pointer tracking-wider transition-all duration-200 text-sm font-['DM_Sans',sans-serif] ${loading
-                ? "bg-[var(--accent)] cursor-not-allowed"
-                : "hover:bg-[var(--accent)] shadow-lg shadow-[var(--accent)]/30 hover:shadow-[var(--accent)]/50"
+
+
+            className={`w-full py-2.5 bg-blackbox-yellow text-blackbox-white font-bold rounded-lg border-none cursor-pointer tracking-wider transition-all duration-200 text-sm font-lato ${loading
+                ? "bg-blackbox-yellow cursor-not-allowed"
+                : "hover:bg-blackbox-yellow/90 shadow-lg shadow-blackbox-yellow/30 hover:shadow-blackblox-yellow/50"
               }`}>
             {loading ? "Iniciando sesión..." : "Iniciar sesión"}
           </button>
+          
         </form>
       </div>
     </div>

--- a/apps/frontend/src/pages/auth/recovery/PassworsRecovery.tsx
+++ b/apps/frontend/src/pages/auth/recovery/PassworsRecovery.tsx
@@ -1,40 +1,48 @@
 import isotipoBlackbox from "@/src/assets/Isotipos/isotipo_blackbox.png";
 import logotipoBlackbox from "@/src/assets/Logo/logotipo_blackbox.png";
 import { Eye, EyeOff } from "lucide-react";
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useMemo } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
 import { useAuthRecovery } from "@/src/hooks/useAuthRecovery";
+import { useDocumentTitle } from "@/src/hooks/useDocumentTitle";
 
 export default function PasswordRecovery() {
+  useDocumentTitle("Recuperar contraseña");
   const [showNew, setShowNew] = useState(false);
   const [showConfirm, setShowConfirm] = useState(false);
   const [newPassword, setNewPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
   const [showModal, setShowModal] = useState(false);
 
-  const { isLoading, error, resetPassword, hasActiveResetFlow, mockData } = useAuthRecovery();
+  const { isLoading, error, resetPassword, hasActiveResetFlow } = useAuthRecovery();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const token = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    return params.get("token") || "";
+  }, [location.search]);
 
-  // Check if user has a valid reset flow when component mounts
+
   useEffect(() => {
-    if (!hasActiveResetFlow()) {
-      console.log('No active reset flow found. Redirecting to forgot password...');
-      // In a real app, you would redirect to the forgot password page
-      console.log('Available test emails:', mockData.testEmails);
+    if (!token && !hasActiveResetFlow()) {
+      navigate("/reset-password", { replace: true });
+
     }
-  }, [hasActiveResetFlow, mockData.testEmails]);
+  }, [hasActiveResetFlow, token]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
     if (newPassword !== confirmPassword) {
-      // Error will be handled by the hook
+      alert("Las contraseñas no coinciden. Por favor, verifica e intenta nuevamente.");
       return;
     }
 
     try {
-      await resetPassword(newPassword);
+      await resetPassword(newPassword, token);
       setShowModal(true);
     } catch (err: any) {
-      // Error is handled by the hook, but we can add additional logging
+      
       console.error('Password reset failed:', err.message);
     }
   };
@@ -42,7 +50,7 @@ export default function PasswordRecovery() {
   return (
     <div className="h-screen flex w-full font-lato overflow-hidden">
       {/* ── Panel izquierdo: fondo gris claro + isotipo ── */}
-      <div className="hidden lg:flex flex-1 h-screen items-center justify-center overflow-hidden">
+      <div className="hidden lg:flex flex-1 bg-white h-screen items-center justify-center overflow-hidden">
         <img
           src={isotipoBlackbox}
           alt="BlackBox Isotipo"
@@ -71,7 +79,7 @@ export default function PasswordRecovery() {
             <p className="text-xs md:text-sm text-slate-500">
               Define tu nueva contraseña para mantener segura tu cuenta.
             </p>
-            
+
           </div>
 
           {/* Formulario */}
@@ -179,7 +187,7 @@ export default function PasswordRecovery() {
             <button
               onClick={() => {
                 setShowModal(false);
-                // navigate("/login"); // Redirigir al login
+                navigate("/login", { replace: true });
               }}
               className="w-full bg-yellow-400 hover:bg-yellow-500 text-slate-900 font-semibold py-2.5 md:py-3 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-yellow-300 text-sm md:text-base"
             >

--- a/apps/frontend/src/routes/AppRoutes.tsx
+++ b/apps/frontend/src/routes/AppRoutes.tsx
@@ -35,7 +35,7 @@ export const AppRoutes: React.FC = () => {
         }
       />,
       <Route
-        path="/auth/password/reset/"
+        path="/reset-password"
         element={
           <PublicRoute>
             <AuthLayout>

--- a/apps/frontend/src/services/api.ts
+++ b/apps/frontend/src/services/api.ts
@@ -15,6 +15,17 @@ import {
   MOCK_HISTORIAL_REPORTE,
 } from "../data/mockData";
 
+const buildErrorMessage = async (response: Response, fallback: string) => {
+  try {
+    const data = await response.json();
+    const msg = data?.error || data?.message;
+    if (msg) return `${fallback} `;
+  } catch {
+
+  }
+  return `${fallback} )`;
+};
+
 export const api = {
   async register(data: any): Promise<{ user: User; message: string }> {
     const response = await fetch(
@@ -26,16 +37,13 @@ export const api = {
       },
     );
 
-    const result = await response.json();
     if (!response.ok) {
-      throw new Error(result.error || "Registration failed");
+      throw new Error(await buildErrorMessage(response, "Registration failed"));
     }
-    return result;
+    return response.json();
   },
 
-  async login(
-    data: any,
-  ): Promise<{ user: User; token: string; message: string }> {
+  async login(data: any,): Promise<{ user: User; token: string; message: string }> {
     const response = await fetch(
       `${API_ENDPOINTS.BASE}${API_ENDPOINTS.AUTH.LOGIN}`,
       {
@@ -45,12 +53,13 @@ export const api = {
       },
     );
 
-    const result = await response.json();
     if (!response.ok) {
-      throw new Error(result.error || "Login failed");
+      throw new Error(await buildErrorMessage(response, "Credenciales inválidas"));
     }
-    return result;
+    return response.json();
   },
+
+
 
   async checkHealth(): Promise<boolean> {
     try {
@@ -70,8 +79,7 @@ export const api = {
       const response = await fetch(`${API_ENDPOINTS.BASE}${API_ENDPOINTS.CHOFERES}`);
       if (!response.ok) {
         if (response.status === 404) return MOCK_CHOFERES;
-        const result = await response.json().catch(() => ({}));
-        throw new Error(result.error || `Error ${response.status}`);
+        throw new Error(await buildErrorMessage(response, "Error"));
       }
       return response.json() as Promise<Chofer[]>;
     } catch {
@@ -103,8 +111,7 @@ export const api = {
       const response = await fetch(`${API_ENDPOINTS.BASE}${API_ENDPOINTS.FLOTA}`);
       if (!response.ok) {
         if (response.status === 404) return MOCK_FLOTA;
-        const result = await response.json().catch(() => ({}));
-        throw new Error(result.error || `Error ${response.status}`);
+        throw new Error(await buildErrorMessage(response, "Error"));
       }
       return response.json() as Promise<UnidadFlota[]>;
     } catch {
@@ -120,8 +127,7 @@ export const api = {
       const response = await fetch(`${API_ENDPOINTS.BASE}${API_ENDPOINTS.HISTORIAL}`);
       if (!response.ok) {
         if (response.status === 404) return MOCK_HISTORIAL;
-        const result = await response.json().catch(() => ({}));
-        throw new Error(result.error || `Error ${response.status}`);
+        throw new Error(await buildErrorMessage(response, "Error"));
       }
       return response.json() as Promise<RegistroHistorial[]>;
     } catch {

--- a/apps/frontend/src/services/service.ts
+++ b/apps/frontend/src/services/service.ts
@@ -1,3 +1,6 @@
+
+
+
 export const getSecurityTip = async (): Promise<string> => {
   // Mock security tips - in production, this would call an actual AI service
   const tips = [

--- a/apps/frontend/src/utils/apiClient.ts
+++ b/apps/frontend/src/utils/apiClient.ts
@@ -1,0 +1,21 @@
+export const apiClient = async (url: string, options: RequestInit = {}) => {
+
+  const token = localStorage.getItem("token");
+
+  const response = await fetch(url, {
+    ...options,
+    headers: {
+      "Content-Type": "application/json",
+      ...(token && { Authorization: `Bearer ${token}` }),
+      ...options.headers,
+    },
+  });
+
+  const data = await response.json();
+
+  if (!response.ok) {
+    throw new Error(data.error || "Request failed");
+  }
+
+  return data;
+};


### PR DESCRIPTION
## Cambios
- Login conectado al backend y mejoras de errores
- Forgot/Reset password integrado con endpoints reales
- Reset password usa token desde URL y redirige a login al éxito

## Notas
- Solo frontend
- El login y recuperacion de contraseña fue probado en local ya que en la api en deploy no hay datos 

## Cómo probar
1. Iniciar frontend
2. Login con credenciales reales
3. Forgot password -> recibe email con token
4. Reset password usando link con token

Crea un usuario para probar en local 
curl -X POST http://localhost:3000/api/auth/register \
  -H "Content-Type: application/json" \
  -d '{
    "company": {
      "name": "Logistica Veloz",
      "usdotNumber": "US-1234567",
      "state": "TX"
    },
    "user": {
      "name": "Juan Admin",
      "email": "dobehak167@medevsa.com",
      "password": "AdminPassword123!"
    }
  }'